### PR TITLE
Discovered and added new test case for validateEmailDomain

### DIFF
--- a/emailvalidator/src/main/java/com/ignacio/validator/emailvalidator/Validate.java
+++ b/emailvalidator/src/main/java/com/ignacio/validator/emailvalidator/Validate.java
@@ -72,11 +72,20 @@ public class Validate {
 	 * @return True if the email's domain is contained within the list of valid domains.
 	 */
 	public static boolean validateEmailDomain(String email, String[] domains){
-		String[] parts = email.split("@");
-		String domain = parts[1];
-		for(String test : domains){
-			if(test.equals(domain)){
-				return true;
+		boolean hasDomain = false;
+		char[] check = email.toCharArray();
+		for(int i = 0; i < check.length; i++)
+			if(check[i] == '@'){
+				if(i + 1 <= check.length)
+					hasDomain = true; //considers a domain any character that occurs after an '@' character
+			}
+		if(hasDomain){
+			String[] parts = email.split("@");
+			String domain = parts[1];
+			for(String test : domains){
+				if(test.equals(domain)){
+					return true;
+				}
 			}
 		}
 		return false;

--- a/emailvalidator/src/test/java/com/ignacio/validator/emailvalidator/ValidateTest.java
+++ b/emailvalidator/src/test/java/com/ignacio/validator/emailvalidator/ValidateTest.java
@@ -66,6 +66,7 @@ public class ValidateTest
      */
     public void testValidateEmailDomain(){
     	assertTrue(Validate.validateEmailDomain("test@gmail.com", domains)); //gmail.com is a valid domain
+    	assertFalse(Validate.validateEmailDomain("nodomain@", domains)); //dpes not have a domain entered, just an '@'
     	assertFalse(Validate.validateEmailDomain("bad@domain", domains));
     }
     


### PR DESCRIPTION
When testing with the UI, discovered a test case that was not accounted for...
attempted to split a string with '@' as a delimiter regardless of if there were characters after the '@' character. This led to a total failure of the validateEmailDomain method and caused the application to crash. Added the test case then changed the code to account for it.